### PR TITLE
Fix empty Python wheel (absolute scikit-build install dest) + stub connect→connector

### DIFF
--- a/bindings/python/CMakeLists.txt
+++ b/bindings/python/CMakeLists.txt
@@ -220,18 +220,19 @@ set_target_properties(nepath_py PROPERTIES
 # ============================================================
 # Install Python module
 # ============================================================
-# Install the compiled module into Python site-packages
+# Install the compiled module into the wheel's NEPath package (relative dest for scikit-build-core;
+# absolute ${Python_SITEARCH} escaped the wheel staging prefix -> empty wheel).
 install(TARGETS nepath_py
-    LIBRARY DESTINATION ${Python_SITEARCH}
+    LIBRARY DESTINATION NEPath
 )
 
 # Install __init__.py to allow 'import NEPath'
-install(TARGETS nepath_py LIBRARY DESTINATION ${Python_SITEARCH}/NEPath)
+install(TARGETS nepath_py LIBRARY DESTINATION NEPath)
 install(FILES 
     ${CMAKE_CURRENT_SOURCE_DIR}/NEPath/__init__.py
     ${CMAKE_CURRENT_SOURCE_DIR}/NEPath/_nepath.pyi
     DESTINATION
-    ${Python_SITEARCH}/NEPath)
+    NEPath)
 
 # Add config file for IncludeIpopt and IncludeGurobi
 configure_file(
@@ -241,4 +242,4 @@ configure_file(
 )
 install(FILES "${CMAKE_CURRENT_BINARY_DIR}/NEPathConfig.py"
         DESTINATION 
-        ${Python_SITEARCH}/NEPath)
+        NEPath)

--- a/bindings/python/NEPath/_nepath.pyi
+++ b/bindings/python/NEPath/_nepath.pyi
@@ -98,7 +98,7 @@ class ContourParallelOptions:
     num_least: int
     """Minimum number of waypoints."""
 
-    connect: ConnectAlgorithm
+    connector: ConnectAlgorithm
     """Connection algorithm."""
 
     def __init__(self) -> None: ...


### PR DESCRIPTION
## Summary

Two fixes to the Python bindings (`bindings/python`), found while building them on macOS (Apple clang 17) / Python 3.13 / scikit-build-core 0.10.

## 1. `pip install .` produces an empty wheel → `ModuleNotFoundError: No module named 'NEPath'`

`bindings/python/CMakeLists.txt` installs the compiled module and package files to the **absolute** `${Python_SITEARCH}`:

```cmake
install(TARGETS nepath_py LIBRARY DESTINATION ${Python_SITEARCH})
install(TARGETS nepath_py LIBRARY DESTINATION ${Python_SITEARCH}/NEPath)
install(FILES .../__init__.py .../_nepath.pyi DESTINATION ${Python_SITEARCH}/NEPath)
```

scikit-build-core builds in an isolated environment and stages the wheel under **its own** `CMAKE_INSTALL_PREFIX`. An absolute `${Python_SITEARCH}` resolves to the ephemeral build interpreter's site-packages, so `cmake --install` writes *outside* the wheel-staging tree and the artifacts are never packaged. Result: a ~1 KB wheel with no `_nepath*.so` and no `NEPath/` package — `pip install .` reports success, then `import NEPath` fails.

**Fix:** use **relative** destinations (`DESTINATION NEPath`), which scikit-build-core maps into the wheel's platlib.

Verified: wheel size **1085 bytes → 131 KB**, `import NEPath` works, and `NEPathPlanner().CP(...)` + `Curve.UnderFillRate(...)` run.

```bash
cd bindings/python
NEPATH_ENABLE_IPOPT=OFF NEPATH_ENABLE_GUROBI=OFF pip install .
python -c "import NEPath; print('ok')"
```

## 2. Type-stub typo: `ContourParallelOptions.connect` → `connector`

`_nepath.pyi` declares `ContourParallelOptions.connect`, but the C++ struct (`include/NEPath/PlanningOptions.h:35`) and the binding (`bindings/python/NEPath/nepath_py.cpp:133`) both expose `connector` (consistent with `NonEquidistantOptions.connector`). Setting `opts.connect = ...` raises `AttributeError: ... Did you mean: 'connector'?`. Stub corrected to `connector`.

## Testing

Built solver-free (Ipopt/Gurobi off) and ran CP, CP+CFS, Zigzag, and the underfill metric on both the demo star contour and a real curved-layer boundary polygon — all import and execute after the fixes.
